### PR TITLE
Bring up-to-date with recent GHCs

### DIFF
--- a/FunGEn.cabal
+++ b/FunGEn.cabal
@@ -39,7 +39,7 @@ description:
 stability:          beta
 cabal-version:      >= 1.8
 build-type:         Simple
-tested-with:        GHC==7.10.3, GHC==8.0
+tested-with:        GHC==7.10.3, GHC==8.0, GHC==8.8.4, GHC==8.10.2
 extra-source-files: 
                     README.md,
                     CHANGES

--- a/FunGEn.cabal
+++ b/FunGEn.cabal
@@ -67,6 +67,8 @@ library
                     Graphics.UI.Fungen.Types,
                     Graphics.UI.Fungen.Util,
                     Graphics.UI.GLUT.Input
+  other-modules:    Paths_FunGEn
+  autogen-modules:  Paths_FunGEn
 
   build-depends:
                     base == 4.*
@@ -79,6 +81,8 @@ executable fungen-hello
   ghc-options: -W
   hs-source-dirs: examples
   main-is:          hello.hs
+  other-modules:    Paths_FunGEn
+  autogen-modules:  Paths_FunGEn
   build-depends:    FunGEn == 1.0.*
                    ,base
                    ,OpenGL
@@ -89,6 +93,8 @@ executable fungen-pong
   ghc-options: -W
   hs-source-dirs: examples
   main-is:          pong/pong.hs
+  other-modules:    Paths_FunGEn
+  autogen-modules:  Paths_FunGEn
   build-depends:    FunGEn == 1.0.*
                    ,base
                    ,OpenGL
@@ -99,6 +105,8 @@ executable fungen-worms
   ghc-options: -W
   hs-source-dirs: examples
   main-is:          worms/worms.hs
+  other-modules:    Paths_FunGEn
+  autogen-modules:  Paths_FunGEn
   build-depends:    FunGEn == 1.0.*
                    ,base
                    ,OpenGL

--- a/Graphics/UI/Fungen/Game.hs
+++ b/Graphics/UI/Fungen/Game.hs
@@ -167,6 +167,9 @@ instance Monad (IOGame t s u v) where
   (>>=) = bindST
   return = unitST
 
+instance MonadFail (IOGame t s u v) where
+  fail s = liftIOtoIOGame (fail s)
+
 runIOGame :: IOGame t s u v a -> Game t s u v -> IO (Game t s u v,a)  -- (a,Game t s u v) the state tuple
 runIOGame (IOG f) g = f g
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
 packages:
 - '.'
-resolver: lts-6.12
+resolver: lts-16.17


### PR DESCRIPTION
The only actual code change is the addition of a trivial MonadFail instance for IOGame. There's also a small handful of config changes to silence warnings and the like. With these changes, I was able to build the package and run its examples without issue using GHCs 8.8.4 and 8.10.2.